### PR TITLE
chore(): update version to 2.5.4 and interface compatibility for WoW 12.0.0

### DIFF
--- a/AutoQuests.toc
+++ b/AutoQuests.toc
@@ -1,10 +1,10 @@
-## Interface: 110002
+## Interface: 120000
 
-## Title: AutoQuests |cfffc4103 v2.5.1|r |cff03befc unverz06|r
+## Title: AutoQuests |cfffc4103 v2.5.4|r |cff03befc unverz06|r
 ## IconTexture: Interface\AddOns\AutoQuests\Icons\AutoQuests.tga
 ## Notes: Takes and returns your quests automatically.
 ## Author: unverz06
-## Version: 2.5.3
+## Version: 2.5.4
 ## X-Curse-Project-ID: 686482
 ## X-Wago-ID: 5NRejvG3
 
@@ -17,7 +17,7 @@ locale/enGB.lua
 locale/enUS.lua
 locale/frFR.lua
 locale/ruRU.lua
-locale/ptBR.lua 
+locale/ptBR.lua
 locale/zhCN.lua
 locale/enCN.lua
 locale/deDE.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 ## x.x.x
 
 > Released
+## 2.5.4
+- Update interface version to 120000 for WoW 12.0.0 Midnight pre-patch compatibility
+
 ## 2.5.3
-- Add locale/ptBR.lua 
+- Add locale/ptBR.lua
 - Add locale/zhCN.lua
 - Add locale/enCN.lua
 - Add locale/deDE.lua

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AutoQuests — v2.5.3
+# AutoQuests — v2.5.4
 <div align="center">
   <img src="https://raw.githubusercontent.com/unverz06/AutoQuests/readme/src/AutoQuest_banner.jpg" alt="banner" width="100%">
 </div>
@@ -17,7 +17,7 @@ Takes and returns your quests automatically.
 - Return multiple quests
 - Return quests with the continue
 
-## Command : 
+## Command :
 - Press Shift or Ctrl or Alt for deactivate Autoquest (is reactivate on release)
 - ```/autoquest off``` or ```/aq off``` for deactivate Autoquests
 - ```/autoquest on``` or ```/aq on```  for reactivate Autoquests


### PR DESCRIPTION
For some reason my wow client refused to load the current version even with 'load out of date addons' option selected. It was simply not running anything. This change is to fix that behavior.