### PR TITLE
feat(): adding new feature for auto-selecting repeatable quests

### DIFF
--- a/AutoQuests.toc
+++ b/AutoQuests.toc
@@ -1,10 +1,10 @@
 ## Interface: 120000
 
-## Title: AutoQuests |cfffc4103 v2.5.4|r |cff03befc unverz06|r
+## Title: AutoQuests |cfffc4103 v2.6.0|r |cff03befc unverz06|r
 ## IconTexture: Interface\AddOns\AutoQuests\Icons\AutoQuests.tga
 ## Notes: Takes and returns your quests automatically.
 ## Author: unverz06
-## Version: 2.5.4
+## Version: 2.6.0
 ## X-Curse-Project-ID: 686482
 ## X-Wago-ID: 5NRejvG3
 

--- a/AutoQuests.toc
+++ b/AutoQuests.toc
@@ -1,10 +1,10 @@
-## Interface: 110002
+## Interface: 120000
 
-## Title: AutoQuests |cfffc4103 v2.5.1|r |cff03befc unverz06|r
+## Title: AutoQuests |cfffc4103 v2.5.4|r |cff03befc unverz06|r
 ## IconTexture: Interface\AddOns\AutoQuests\Icons\AutoQuests.tga
 ## Notes: Takes and returns your quests automatically.
 ## Author: unverz06
-## Version: 2.5.3
+## Version: 2.5.4
 ## X-Curse-Project-ID: 686482
 ## X-Wago-ID: 5NRejvG3
 
@@ -17,7 +17,7 @@ locale/enGB.lua
 locale/enUS.lua
 locale/frFR.lua
 locale/ruRU.lua
-locale/ptBR.lua 
+locale/ptBR.lua
 locale/zhCN.lua
 locale/enCN.lua
 locale/deDE.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## x.x.x
 
 > Released
+## 2.6.0
+- Auto-select first repeatable quest when multiple are available in gossip
+
 ## 2.5.4
 - Update interface version to 120000 for WoW 12.0.0 Midnight pre-patch compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 ## x.x.x
 
 > Released
+## 2.5.4
+- Update interface version to 120000 for WoW 12.0.0 Midnight pre-patch compatibility
+
 ## 2.5.3
-- Add locale/ptBR.lua 
+- Add locale/ptBR.lua
 - Add locale/zhCN.lua
 - Add locale/enCN.lua
 - Add locale/deDE.lua

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AutoQuests — v2.5.3
+# AutoQuests — v2.5.4
 <div align="center">
   <img src="https://raw.githubusercontent.com/unverz06/AutoQuests/readme/src/AutoQuest_banner.jpg" alt="banner" width="100%">
 </div>
@@ -17,7 +17,7 @@ Takes and returns your quests automatically.
 - Return multiple quests
 - Return quests with the continue
 
-## Command : 
+## Command :
 - Press Shift or Ctrl or Alt for deactivate Autoquest (is reactivate on release)
 - ```/autoquest off``` or ```/aq off``` for deactivate Autoquests
 - ```/autoquest on``` or ```/aq on```  for reactivate Autoquests

--- a/main.lua
+++ b/main.lua
@@ -1,20 +1,20 @@
---[[ 
-    Importation de la table de localisation 
+--[[
+    Importation de la table de localisation
 ]]
 local _, L = ...
 
 local playerName = UnitName("player")
 local defaultRewardIndex = 1
 
---[[ 
-    Fonction d'affichage de message 
+--[[
+    Fonction d'affichage de message
 ]]
 function printMessage(message)
     DEFAULT_CHAT_FRAME:AddMessage(message, 1.0, 1.0, 0.0)
 end
 
---[[ 
-    Fonction principale pour gérer les événements liés aux quêtes 
+--[[
+    Fonction principale pour gérer les événements liés aux quêtes
 ]]
 function AutoQuestsHandler(self, event, ...)
     if not L.status or IsShiftKeyDown() or IsControlKeyDown() or IsAltKeyDown() then
@@ -34,7 +34,7 @@ function AutoQuestsHandler(self, event, ...)
     end
 end
 
---[[ 
+--[[
     Fonction pour gérer l'événement GOSSIP_SHOW
 ]]
 function HandleGossipShow()
@@ -48,14 +48,21 @@ function HandleGossipShow()
         C_GossipInfo.SelectOption(gossipOptions[1].gossipOptionID)
     else
         local questOptionsCount = 0
+        local firstQuestOption = nil
         for _, option in ipairs(gossipOptions) do
             if option.flags == 1 then
                 questOptionsCount = questOptionsCount + 1
+                if firstQuestOption == nil then
+                    firstQuestOption = option
+                end
             end
         end
         if questOptionsCount > 1 then
             printMessage(L.TITLE .. playerName .. L.GOSSIP)
             PlaySound(5274, "master")
+            if firstQuestOption then
+                C_GossipInfo.SelectOption(firstQuestOption.gossipOptionID)
+            end
         elseif questOptionsCount == 1 then
             C_GossipInfo.SelectOption(gossipOptions[1].gossipOptionID)
         end
@@ -67,8 +74,10 @@ function HandleGossipShow()
                 C_GossipInfo.SelectAvailableQuest(quest.questID)
             end
         end
-        if availableQuests[1].repeatable then
-            printMessage(L.TITLE .. playerName .. L.REPEATABLE)
+        if availableQuests[1] then
+            if availableQuests[1].repeatable and nAvailable > 1 then
+                C_GossipInfo.SelectAvailableQuest(availableQuests[1].questID)
+            end
         end
     elseif nActive > 0 then
         for i, quest in ipairs(activeQuests) do
@@ -79,8 +88,8 @@ function HandleGossipShow()
     end
 end
 
---[[ 
-    Fonction pour gérer l'événement QUEST_GREETING 
+--[[
+    Fonction pour gérer l'événement QUEST_GREETING
 ]]
 function HandleQuestGreeting()
     local availableQuestsCount = GetNumAvailableQuests()
@@ -97,8 +106,8 @@ function HandleQuestGreeting()
     end
 end
 
---[[ 
-    Fonction pour gérer l'événement QUEST_COMPLETE 
+--[[
+    Fonction pour gérer l'événement QUEST_COMPLETE
 ]]
 function HandleQuestCompletion()
     local rewardCount = GetNumQuestChoices()
@@ -110,8 +119,8 @@ function HandleQuestCompletion()
     end
 end
 
---[[ 
-    Enregistrement des événements de quêtes 
+--[[
+    Enregistrement des événements de quêtes
 ]]
 function RegisterAutoQuestsEvents()
     L.status = true
@@ -126,8 +135,8 @@ function RegisterAutoQuestsEvents()
     frame:SetScript("OnEvent", AutoQuestsHandler)
 end
 
---[[ 
-    Commandes slash pour activer/désactiver l'addon 
+--[[
+    Commandes slash pour activer/désactiver l'addon
 ]]
 SLASH_AUTOQUEST1 = "/autoquest"
 SLASH_AUTOQUEST2 = "/aq"
@@ -148,8 +157,8 @@ SlashCmdList["AUTOQUEST"] = function(msg)
     end
 end
 
---[[ 
-    Gestionnaire de l'événement de connexion du joueur 
+--[[
+    Gestionnaire de l'événement de connexion du joueur
 ]]
 loginFrame = CreateFrame("Frame")
 loginFrame:RegisterEvent("PLAYER_LOGIN")


### PR DESCRIPTION
When opening an npc with multiple repeatable quests (like the pvp guy at dornogal), the addon asks me to pick a repeatable quest. This change changes that behavior to make the addon simply pick the first one automatically to auto-accept it.